### PR TITLE
vtools: analysis: add a check to avoid divide by zero

### DIFF
--- a/src/vtools-analysis.py
+++ b/src/vtools-analysis.py
@@ -191,7 +191,7 @@ def get_frame_dups_info(df, frame_dups_psnr, debug):
                     print(f"{frame_num=} {dup_length=}")
             dup_length = 0
         last_frame_num = frame_num
-    if frame_dups == 0:
+    if frame_dups == 0 or len(dup_length_list) == 0:
         frame_dups_average_length = 0.0
     else:
         frame_dups_average_length = sum(dup_length_list) / len(dup_length_list)


### PR DESCRIPTION
This is to fix this issue
```
  File "/Users/karthickvenkat/Desktop/Scripts/vtools-master/src/vtools-ffprobe.py", line 52, in get_frames_information
    df = parse_ffprobe_frames_output(out, debug)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/karthickvenkat/Desktop/Scripts/vtools-master/src/vtools-ffprobe.py", line 183, in parse_ffprobe_frames_output
    frame_dict = parse_ffprobe_output(out, debug)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/karthickvenkat/Desktop/Scripts/vtools-master/src/vtools-ffprobe.py", line 281, in parse_ffprobe_output
    ((int(frame["pkt_size"]) *  / pkt_duration_time)
```