### PR TITLE
vtools: analysis: add audio info

### DIFF
--- a/src/vtools-analysis.py
+++ b/src/vtools-analysis.py
@@ -114,7 +114,7 @@ def summarize(infile, df, config_dict, debug):
         vals.append(val)
     # add derived values
     if "pkt_duration_time" in df:
-        key = "video_duration"
+        key = "video_duration_time"
         val = df["pkt_duration_time"].astype(float).sum()
         keys.append(key)
         vals.append(val)
@@ -178,7 +178,7 @@ def summarize(infile, df, config_dict, debug):
         vals.append(sample_rate)
         keys.append("audio_bitrate")
         vals.append(bitrate)
-        keys.append("audio_duration")
+        keys.append("audio_duration_time")
         vals.append(duration)
     # return summary dataframe
     df = pd.DataFrame(columns=keys)
@@ -557,6 +557,13 @@ def get_options(argv):
         default=default_values["dump_audio_info"],
         help="Dump audio information%s"
         % (" [default]" if default_values["dump_audio_info"] else ""),
+    )
+    parser.add_argument(
+        "--no-dump-audio-info",
+        dest="dump_audio_info",
+        action="store_false",
+        help="Do not dump audio information%s"
+        % (" [default]" if not default_values["dump_audio_info"] else ""),
     )
 
     # do the parsing

--- a/src/vtools-analysis.py
+++ b/src/vtools-analysis.py
@@ -44,6 +44,7 @@ default_values = {
     "filter": "frames",
     "infile_list": [],
     "outfile": None,
+    "dump_audio_info": False,
 }
 
 
@@ -113,7 +114,7 @@ def summarize(infile, df, config_dict, debug):
         vals.append(val)
     # add derived values
     if "pkt_duration_time" in df:
-        key = "file_duration_time"
+        key = "video_duration"
         val = df["pkt_duration_time"].astype(float).sum()
         keys.append(key)
         vals.append(val)
@@ -169,6 +170,16 @@ def summarize(infile, df, config_dict, debug):
     vals.append(frame_drop_average_length)
     keys.append("frame_drop_text_list")
     vals.append(frame_drop_text_list)
+    if config_dict['dump_audio_info'] == True:
+        sample_rate, bitrate, duration = (
+            vtools_ffprobe.get_audio_info(infile)
+        )
+        keys.append("audio_sample_rate")
+        vals.append(sample_rate)
+        keys.append("audio_bitrate")
+        vals.append(bitrate)
+        keys.append("audio_duration")
+        vals.append(duration)
     # return summary dataframe
     df = pd.DataFrame(columns=keys)
     df.loc[len(df.index)] = vals
@@ -539,6 +550,15 @@ def get_options(argv):
         metavar="output-file",
         help="output file",
     )
+    parser.add_argument(
+        "--dump-audio-info",
+        dest="dump_audio_info",
+        action="store_true",
+        default=default_values["dump_audio_info"],
+        help="Dump audio information%s"
+        % (" [default]" if default_values["dump_audio_info"] else ""),
+    )
+
     # do the parsing
     options = parser.parse_args(argv[1:])
     if options.version:

--- a/src/vtools-common.py
+++ b/src/vtools-common.py
@@ -18,6 +18,7 @@ CONFIG_KEY_LIST = (
     "frame_dups",
     "frame_dups_psnr",
     "qpextract_bin",
+    "dump_audio_info",
 )
 
 

--- a/src/vtools-ffprobe.py
+++ b/src/vtools-ffprobe.py
@@ -258,7 +258,7 @@ PREFERRED_KEY_ORDER = [
     # audio information
     "audio_sample_rate",
     "audio_bitrate",
-    "audio_duration",
+    "audio_duration_time",
 ]
 
 


### PR DESCRIPTION
Dump audio information from the video file.
This is to validate video freeze by comparing a/v duration.
The validation.py is a internal file, not added in this repo. 

The newly added three columns are at the end of the line:
<img width="850" alt="image" src="https://github.com/chemag/vtools/assets/4551215/498e67f6-8e5c-49b9-a931-7cd610187396">
