### PR TITLE
vtools: ffprobe:pkt_duration_time is deprecated

### DIFF
--- a/src/vtools-analysis.py
+++ b/src/vtools-analysis.py
@@ -113,9 +113,10 @@ def summarize(infile, df, config_dict, debug):
         keys.append(key)
         vals.append(val)
     # add derived values
-    if "pkt_duration_time" in df:
+    if "pkt_duration_time_ms" in df:
         key = "video_duration_time"
-        val = df["pkt_duration_time"].astype(float).sum()
+        # duration is in seconds
+        val = df["pkt_duration_time_ms"].astype(float).sum() / 1000
         keys.append(key)
         vals.append(val)
     if "pict_type" in df:

--- a/src/vtools-ffprobe.py
+++ b/src/vtools-ffprobe.py
@@ -296,10 +296,11 @@ def parse_ffprobe_output(out, debug):
         frame["bpp"] = (int(frame["pkt_size"]) * 8) / (
             int(frame["width"]) * int(frame["height"])
         )
-        # get the duration of this frame
-        # some file produce duration_time instead of pkt_duration_time
+        # pkt_duration_time is deprecated, use duration_time
         if "pkt_duration_time" in frame:
             pkt_duration_time = float(frame["pkt_duration_time"])
+        elif "duration_time" in frame:
+            pkt_duration_time = float(frame["duration_time"])
         else:
             # TODO(chema): this is measuring the time after this frame
             if prev_frame_pts_time is None:


### PR DESCRIPTION
Some parameters from the ffprobe output are deprecated.
For example of a comparison between v7.0 and below
ffprobe -print_format json -count_frames -show_frames xxx.mp4
<img width="737" alt="image" src="https://github.com/chemag/vtools/assets/4551215/58b00265-94ad-45cf-9f84-fa7eb2f6348f">

avutil: remove deprecated FF_API_PKT_DURATION
https://github.com/FFmpeg/FFmpeg/commit/b8fef7e9c520b3923b32813b6a82c154c74402dc

This PR is to fix the issue. Otherwise, the file_duration_time is empty in csv.